### PR TITLE
feat: allow specifying an initial value for a prompt

### DIFF
--- a/beaupy/_beaupy.py
+++ b/beaupy/_beaupy.py
@@ -73,6 +73,7 @@ def prompt(
     secure: bool = False,
     raise_validation_fail: bool = True,
     raise_type_conversion_fail: bool = True,
+    initial_value: Optional[str] = None,
 ) -> TargetType:
     """Function that prompts the user for written input
 
@@ -85,6 +86,7 @@ def prompt(
                                                 the error will be reported onto the console. Defaults to True.
         raise_type_conversion_fail (bool, optional): If True, invalid inputs will raise `rich.internals.ConversionError`, else
                                                      the error will be reported onto the console. Defaults to True.
+        initial_value (str, optional): If present, the value is placed in the prompt as the default value.
 
     Raises:
         ValidationError: Raised if validation with provided validator fails
@@ -96,8 +98,8 @@ def prompt(
     """
     rendered = ''
     with _cursor_hidden(console), Live(rendered, console=console, auto_refresh=False, transient=True) as live:
-        value: List[str] = []
-        cursor_index = 0
+        value: List[str] = [*initial_value] if initial_value else []
+        cursor_index = len(initial_value) if initial_value else 0
         error: str = ''
         while True:
             rendered = _render_prompt(secure, value, prompt, cursor_index, error)

--- a/test/beaupy_prompt_test.py
+++ b/test/beaupy_prompt_test.py
@@ -210,3 +210,57 @@ def _():
 
     with raises(KeyboardInterrupt):
         prompt(prompt="Try test")
+
+
+@test("Prompt with initial value without further input", tags=["v1", "prompt"])
+def _():
+    steps = iter([readchar.key.ENTER])
+    readchar.readkey = lambda: next(steps)
+    Live.update = mock.MagicMock()
+    res = prompt(prompt="Try test", initial_value="Hello, World!")
+    assert res == "Hello, World!"
+
+
+@test("Prompt with initial value and further input", tags=["v1", "prompt"])
+def _():
+    steps = iter([*"World!", readchar.key.ENTER])
+    readchar.readkey = lambda: next(steps)
+    Live.update = mock.MagicMock()
+    res = prompt(prompt="Try test", initial_value="Hello, ")
+    assert res == "Hello, World!"
+
+
+@test("Prompt with initial value and then backspace", tags=["v1", "prompt"])
+def _():
+    steps = iter([readchar.key.BACKSPACE, readchar.key.ENTER])
+    readchar.readkey = lambda: next(steps)
+    Live.update = mock.MagicMock()
+    res = prompt(prompt="Try test", initial_value="Hello,")
+    assert res == "Hello"
+
+
+@test("Prompt with empty initial value", tags=["v1", "prompt"])
+def _():
+    steps = iter([readchar.key.ENTER])
+    readchar.readkey = lambda: next(steps)
+    Live.update = mock.MagicMock()
+    res = prompt(prompt="Try test", initial_value="")
+    assert res == ""
+
+
+@test("Prompt with None initial value", tags=["v1", "prompt"])
+def _():
+    steps = iter([readchar.key.ENTER])
+    readchar.readkey = lambda: next(steps)
+    Live.update = mock.MagicMock()
+    res = prompt(prompt="Try test", initial_value=None)
+    assert res == ""
+
+
+@test("Prompt with None initial value and then backspace", tags=["v1", "prompt"])
+def _():
+    steps = iter([readchar.key.BACKSPACE, readchar.key.ENTER])
+    readchar.readkey = lambda: next(steps)
+    Live.update = mock.MagicMock()
+    res = prompt(prompt="Try test", initial_value=None)
+    assert res == ""


### PR DESCRIPTION
This change allows the user to specify an initial value for a prompt, similar to how "select" prompts allow specifying the initial position of the cursor.
If an initial value is given, it is automatically placed in the prompt, and the cursor is moved to the end, as if the user just typed this input himself.