### PR TITLE
feat: add the actual key that was used to trigger a KeyboardInterrupt

### DIFF
--- a/beaupy/_beaupy.py
+++ b/beaupy/_beaupy.py
@@ -137,7 +137,7 @@ def prompt(
                     cursor_index += 1
             elif keypress in DefaultKeys.interrupt:
                 if Config.raise_on_interrupt:
-                    raise KeyboardInterrupt
+                    raise KeyboardInterrupt(keypress)
                 return None
             else:
                 value.insert(cursor_index, keypress)
@@ -217,7 +217,7 @@ def select(
                 return options[index]
             elif keypress in DefaultKeys.interrupt:
                 if Config.raise_on_interrupt:
-                    raise KeyboardInterrupt
+                    raise KeyboardInterrupt(keypress)
                 return None
 
 
@@ -328,7 +328,7 @@ def select_multiple(
                     break
             elif keypress in DefaultKeys.interrupt:
                 if Config.raise_on_interrupt:
-                    raise KeyboardInterrupt
+                    raise KeyboardInterrupt(keypress)
                 return []
         if return_indices:
             return ticked_indices
@@ -395,7 +395,7 @@ def confirm(
                     current_message = current_message[:-1]
             elif keypress in DefaultKeys.interrupt:
                 if Config.raise_on_interrupt:
-                    raise KeyboardInterrupt
+                    raise KeyboardInterrupt(keypress)
                 return None
             elif keypress in DefaultKeys.confirm:
                 if is_selected:

--- a/test/beaupy_confirm_test.py
+++ b/test/beaupy_confirm_test.py
@@ -269,8 +269,9 @@ def _():
     Config.raise_on_interrupt = True
     readchar.readkey = lambda: next(steps)
 
-    with raises(KeyboardInterrupt):
+    with raises(KeyboardInterrupt) as ex:
         confirm(question="Test", cursor_style="red")
+    assert ex.raised.args[0] == readchar.key.CTRL_C
 
 
 @test("`confirm` with `Test` as a question, typing `N` and pressing `\\t`", tags=["v1", "confirm"])

--- a/test/beaupy_prompt_test.py
+++ b/test/beaupy_prompt_test.py
@@ -201,15 +201,15 @@ def _():
     assert ret is None
 
 
-@test("Prompt with interrupt and raise on keyboard iterrupt as True", tags=["v1", "prompt"])
+@test("Prompt with interrupt and raise on keyboard interrupt as True", tags=["v1", "prompt"])
 def _():
     steps = iter([readchar.key.CTRL_C])
     Config.raise_on_interrupt = True
     readchar.readkey = lambda: next(steps)
     Live.update = mock.MagicMock()
-
-    with raises(KeyboardInterrupt):
+    with raises(KeyboardInterrupt) as ex:
         prompt(prompt="Try test")
+    assert ex.raised.args[0] == readchar.key.CTRL_C
 
 
 @test("Prompt with initial value without further input", tags=["v1", "prompt"])

--- a/test/beaupy_select_multiple_test.py
+++ b/test/beaupy_select_multiple_test.py
@@ -222,8 +222,9 @@ def _():
     Config.raise_on_interrupt = True
     readchar.readkey = lambda: next(steps)
     Live.update = mock.MagicMock()
-    with raises(KeyboardInterrupt):
+    with raises(KeyboardInterrupt) as ex:
         select_multiple(options=["test1", "test2"], tick_character="😋")
+    assert ex.raised.args[0] == readchar.key.CTRL_C
 
 
 @test("`select_multiple` with 2 options and invalid tick style", tags=["v1", "select_multiple"])

--- a/test/beaupy_select_test.py
+++ b/test/beaupy_select_test.py
@@ -190,13 +190,14 @@ def _():
     steps = iter([readchar.key.CTRL_C])
     Config.raise_on_interrupt = True
     readchar.readkey = lambda: next(steps)
-    with raises(KeyboardInterrupt):
+    with raises(KeyboardInterrupt) as ex:
         select(
             options=["test1", "test2", "test3", "test4"],
             cursor="x",
             cursor_style="green",
             cursor_index=1,
         )
+    assert ex.raised.args[0] == readchar.key.CTRL_C
 
 
 @test("`select` with 2 options and invalid cursor style", tags=["v1", "select"])


### PR DESCRIPTION
The key that the user pressed to trigger the KeyboardInterrupt is now added to the exception as the first argument. This is useful for handling interrupts triggered by  different keys in different ways. For example: using Ctrl-C to quit, and ESC (or some other key) as a "back" button.