### PR TITLE
feat: Support the delete, home, end, up, and down keys in text input

### DIFF
--- a/beaupy/_beaupy.py
+++ b/beaupy/_beaupy.py
@@ -31,18 +31,24 @@ class DefaultKeys:
     """A map of default keybindings.
 
     Attributes:
-        interrupt(List[str]): Keys that cause a keyboard interrupt.
+        escape(List[str]): Keys that escape the current context.
         select(List[str]): Keys that trigger list element selection.
         confirm(List[str]): Keys that trigger list confirmation.
-        delete(List[str]): Keys that trigger character deletion.
+        backspace(List[str]): Keys that trigger deletion of the previous character.
+        delete(List[str]): Keys that trigger deletion of the next character.
         down(List[str]): Keys that select the element below.
         up(List[str]): Keys that select the element above.
+        left(List[str]): Keys that select the element to the left.
+        right(List[str]): Keys that select the element to the right.
+        home(List[str]): Keys that move to the beginning of the context.
+        end(List[str]): Keys that move to the end of the context.
     """
 
     escape: List[str] = [key.ESC]
     select: List[str] = [key.SPACE]
     confirm: List[str] = [key.ENTER]
-    delete: List[str] = [key.BACKSPACE]
+    backspace: List[str] = [key.BACKSPACE]
+    delete: List[str] = [key.DELETE]
     down: List[str] = [key.DOWN]
     up: List[str] = [key.UP]
     left: List[str] = [key.LEFT]
@@ -129,7 +135,7 @@ def prompt(
                     error = f"Input {'<secure_input>' if secure else '`'+str_value+'`'} cannot be converted to type `{target_type}`"
                     if raise_type_conversion_fail:
                         raise ConversionError(error) from None
-            elif keypress in DefaultKeys.delete:
+            elif keypress in DefaultKeys.backspace:
                 if cursor_index > 0:
                     cursor_index -= 1
                     del value[cursor_index]
@@ -141,6 +147,15 @@ def prompt(
                     cursor_index += 1
             elif keypress in DefaultKeys.escape:
                 return None
+            elif keypress in DefaultKeys.up + DefaultKeys.down:
+                pass
+            elif keypress in DefaultKeys.home:
+                cursor_index = 0
+            elif keypress in DefaultKeys.end:
+                cursor_index = len(value)
+            elif keypress in DefaultKeys.delete:
+                if cursor_index < len(value):
+                    del value[cursor_index]
             else:
                 value.insert(cursor_index, keypress)
                 cursor_index += 1
@@ -404,7 +419,7 @@ def confirm(
                 is_yes = not is_yes
                 is_selected = True
                 current_message = yes_text if is_yes else no_text
-            elif keypress in DefaultKeys.delete:
+            elif keypress in DefaultKeys.backspace:
                 if current_message:
                     current_message = current_message[:-1]
             elif keypress in DefaultKeys.escape:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,5 +137,5 @@ pydoc-markdown = "^4.6.3"
 types-emoji = "^2.0.1"
 
 [build-system]
-requires = ['poetry-core>=1.0.0']
+requires = ['poetry-core>=1.2.0']
 build-backend = 'poetry.core.masonry.api'

--- a/test/beaupy_prompt_test.py
+++ b/test/beaupy_prompt_test.py
@@ -195,7 +195,7 @@ def _():
     assert res == "No"
 
 
-@test("Prompt with interrupt and raise on keyboard iterrupt as False")
+@test("Prompt with interrupt and raise on keyboard interrupt as False")
 def _():
     Config.raise_on_interrupt = False
     Live.update = mock.MagicMock()
@@ -265,3 +265,63 @@ def _():
     Live.update = mock.MagicMock()
     res = prompt(prompt="Try test", initial_value=None)
     assert res == ""
+
+
+@test("Prompt with typing `Hello`, pressing home, and then deleting one char")
+def _():
+    steps = iter([*"Hello", beaupy.key.HOME, beaupy.key.DELETE, beaupy.key.ENTER])
+
+    click.getchar = lambda: next(steps)
+    Live.update = mock.MagicMock()
+    res = prompt(prompt="Try test")
+    assert res == "ello"
+
+
+@test("Prompt with typing `Hello`, pressing home, pressing end, and then backspacing one char")
+def _():
+    steps = iter([*"Hello", beaupy.key.HOME, beaupy.key.END, beaupy.key.BACKSPACE, beaupy.key.ENTER])
+
+    click.getchar = lambda: next(steps)
+    Live.update = mock.MagicMock()
+    res = prompt(prompt="Try test")
+    assert res == "Hell"
+
+
+@test("Prompt with typing `Hello`, pressing up and down, and making sure they don't change the result")
+def _():
+    steps = iter([*"Hello", beaupy.key.UP, beaupy.key.DOWN, beaupy.key.ENTER])
+
+    click.getchar = lambda: next(steps)
+    Live.update = mock.MagicMock()
+    res = prompt(prompt="Try test")
+    assert res == "Hello"
+
+
+@test("Verify that pressing delete on empty input doesn't fail")
+def _():
+    steps = iter([beaupy.key.DELETE, beaupy.key.ENTER])
+
+    click.getchar = lambda: next(steps)
+    Live.update = mock.MagicMock()
+    res = prompt(prompt="Try test")
+    assert res == ""
+
+
+@test("Verify that pressing delete at the end of the input doesn't change anything")
+def _():
+    steps = iter([*"Hello", beaupy.key.DELETE, beaupy.key.ENTER])
+
+    click.getchar = lambda: next(steps)
+    Live.update = mock.MagicMock()
+    res = prompt(prompt="Try test")
+    assert res == "Hello"
+
+
+@test("Verify that home and end are working properly")
+def _():
+    steps = iter([*"ell", beaupy.key.HOME, "H", beaupy.key.END, "o", beaupy.key.ENTER])
+
+    click.getchar = lambda: next(steps)
+    Live.update = mock.MagicMock()
+    res = prompt(prompt="Try test")
+    assert res == "Hello"


### PR DESCRIPTION
Before this commit, the up and down keys would input weird characters during text input, and the home, end, and delete keys did not work as expected.
Now, all these keys behave as expected.