### PR TITLE
feat: Support multi-line input in prompts

### DIFF
--- a/beaupy/_internals.py
+++ b/beaupy/_internals.py
@@ -40,7 +40,7 @@ def _update_rendered(live: Live, renderable: Union[ConsoleRenderable, str]) -> N
     live.refresh()
 
 
-def _render_prompt(secure: bool, typed_values: List[str], prompt: str, cursor_position: int, error: str) -> str:
+def _render_prompt(secure: bool, typed_values: List[str], prompt: str, cursor_position: int, error: str, multiline: bool = False) -> str:
     render_value = (len(typed_values) * '*' if secure else ''.join(typed_values)) + ' '
     render_value = (
         render_value[:cursor_position]
@@ -49,7 +49,12 @@ def _render_prompt(secure: bool, typed_values: List[str], prompt: str, cursor_po
         + '[/black on white]'  # noqa: W503
         + render_value[(cursor_position + 1) :]  # noqa: W503,E203
     )
-    render_value = f'{prompt}\n> {render_value}\n\n(Confirm with [bold]enter[/bold])'
+    render_value = '\n> '.join(render_value.splitlines(keepends=True))
+    if multiline:
+        confirm_msg = '(Use [bold]enter[/bold] to insert a new line. Confirm with [bold]alt-enter[/bold])'
+    else:
+        confirm_msg = '(Confirm with [bold]enter[/bold])'
+    render_value = f'{prompt}\n> {render_value}\n\n{confirm_msg}'
     if error:
         render_value = f'{render_value}\n[red]Error:[/red] {error}'
     return render_value

--- a/beaupy/_internals.py
+++ b/beaupy/_internals.py
@@ -51,7 +51,7 @@ def _render_prompt(secure: bool, typed_values: List[str], prompt: str, cursor_po
     )
     render_value = '\n> '.join(render_value.splitlines(keepends=True))
     if multiline:
-        confirm_msg = '(Use [bold]enter[/bold] to insert a new line. Confirm with [bold]alt-enter[/bold])'
+        confirm_msg = '(Press [bold]enter[/bold] twice to confirm)'
     else:
         confirm_msg = '(Confirm with [bold]enter[/bold])'
     render_value = f'{prompt}\n> {render_value}\n\n{confirm_msg}'

--- a/beaupy/key/__init__.py
+++ b/beaupy/key/__init__.py
@@ -1,7 +1,6 @@
 from beaupy.key import _posix_key as posix_keys  # noqa: F401
 from beaupy.key._key import CTRL_Y  # noqa: F403,F401
 from beaupy.key._key import (  # noqa: F401
-    ALT_ENTER,
     BACKSPACE,
     CR,
     CTRL_A,

--- a/beaupy/key/__init__.py
+++ b/beaupy/key/__init__.py
@@ -1,6 +1,7 @@
 from beaupy.key import _posix_key as posix_keys  # noqa: F401
 from beaupy.key._key import CTRL_Y  # noqa: F403,F401
 from beaupy.key._key import (  # noqa: F401
+    ALT_ENTER,
     BACKSPACE,
     CR,
     CTRL_A,

--- a/beaupy/key/_key.py
+++ b/beaupy/key/_key.py
@@ -34,8 +34,6 @@ CTRL_V = '\x16'
 CTRL_W = '\x17'
 CTRL_Y = '\x19'
 
-# ALT
-ALT_ENTER = '\x1b\r'
 
 if platform.startswith(('linux', 'darwin')):  # pragma: no cover
     # common

--- a/beaupy/key/_key.py
+++ b/beaupy/key/_key.py
@@ -34,6 +34,9 @@ CTRL_V = '\x16'
 CTRL_W = '\x17'
 CTRL_Y = '\x19'
 
+# ALT
+ALT_ENTER = '\x1b\r'
+
 if platform.startswith(('linux', 'darwin')):  # pragma: no cover
     # common
     BACKSPACE = '\x7f'

--- a/test/beaupy_prompt_test.py
+++ b/test/beaupy_prompt_test.py
@@ -325,3 +325,13 @@ def _():
     Live.update = mock.MagicMock()
     res = prompt(prompt="Try test")
     assert res == "Hello"
+
+
+@test("Test inputting multiline string")
+def _():
+    steps = iter(["A", beaupy.key.ENTER, "B", beaupy.key.ENTER, "C", beaupy.key.ALT_ENTER])
+
+    click.getchar = lambda: next(steps)
+    Live.update = mock.MagicMock()
+    res = prompt(prompt="Try test", multiline=True)
+    assert res == "A\nB\nC"


### PR DESCRIPTION
This commit adds an optional `multiline` flag to `prompt`, allowing users to input multi-line strings. To confirm the input, users may use alt-enter.

Caveats:
1. I don't have Linux and Windows setups to test this on, possible bugs there due to OS-dependent line-separators, as well as ALT_ENTER.
2. I haven't implemented up/down keys when in multiline strings, as it's non-trivial. I might implement it in a separate PR.