### PR TITLE
Better "select" & "select_multiple" Scrolling.

### DIFF
--- a/beaupy/_beaupy.py
+++ b/beaupy/_beaupy.py
@@ -227,18 +227,11 @@ def select(
                     raise KeyboardInterrupt()
                 return None
             elif keypress in DefaultKeys.up:
-                if index == 0: #Check if index is first option in list.
-                    if keypress in DefaultKeys.up: #If key pressed is up, set index to last item in list.
-                        index = len(options)
-                if index > 0:
-                    index -= 1
+                index -= 1
+                index = index % len(options)
             elif keypress in DefaultKeys.down:
-                if index == len(options)-1: #Chek if index is last option in list.
-                    if keypress in DefaultKeys.down: #If key press is "down", set index to 0.
-                        index = 0
-                        continue # "continue" is added because the if check below is True and "index += 1" is still executed.
-                if index < len(options) - 1:
-                    index += 1
+                index += 1
+                index = index % len(options)
             elif keypress in DefaultKeys.confirm:
                 if return_index:
                     return index
@@ -306,7 +299,6 @@ def select_multiple(
 
         index = cursor_index
 
-        max_index = len(options) - (1 if True else 0)
         error_message = ''
         while True:
             rendered = (
@@ -335,18 +327,11 @@ def select_multiple(
                     raise KeyboardInterrupt()
                 return []
             elif keypress in DefaultKeys.up:
-                if index == 0: #Check if index is first option in list.
-                    if keypress in DefaultKeys.up: #If key pressed is up, set index to last item in list.
-                        index = len(options)
-                if index > 0:
-                    index -= 1
+                index -= 1
+                index = index % len(options)
             elif keypress in DefaultKeys.down:
-                if index == len(options)-1: #Chek if index is last option in list.
-                    if keypress in DefaultKeys.down: #If key press is "down", set index to 0.
-                        index = 0
-                        continue # "continue" is added because the if check below is True and "index += 1" is still executed.
-                if index + 1 <= max_index:
-                    index += 1
+                index += 1
+                index = index % len(options)
             elif keypress in DefaultKeys.select:
                 if index in ticked_indices:
                     ticked_indices.remove(index)

--- a/beaupy/_beaupy.py
+++ b/beaupy/_beaupy.py
@@ -227,9 +227,16 @@ def select(
                     raise KeyboardInterrupt()
                 return None
             elif keypress in DefaultKeys.up:
+                if index == 0: #Check if index is first option in list.
+                    if keypress in DefaultKeys.up: #If key pressed is up, set index to last item in list.
+                        index = len(options)
                 if index > 0:
                     index -= 1
             elif keypress in DefaultKeys.down:
+                if index == len(options)-1: #Chek if index is last option in list.
+                    if keypress in DefaultKeys.down: #If key press is "down", set index to 0.
+                        index = 0
+                        continue # "continue" is added because the if check below is True and "index += 1" is still executed.
                 if index < len(options) - 1:
                     index += 1
             elif keypress in DefaultKeys.confirm:
@@ -328,9 +335,16 @@ def select_multiple(
                     raise KeyboardInterrupt()
                 return []
             elif keypress in DefaultKeys.up:
+                if index == 0: #Check if index is first option in list.
+                    if keypress in DefaultKeys.up: #If key pressed is up, set index to last item in list.
+                        index = len(options)
                 if index > 0:
                     index -= 1
             elif keypress in DefaultKeys.down:
+                if index == len(options)-1: #Chek if index is last option in list.
+                    if keypress in DefaultKeys.down: #If key press is "down", set index to 0.
+                        index = 0
+                        continue # "continue" is added because the if check below is True and "index += 1" is still executed.
                 if index + 1 <= max_index:
                     index += 1
             elif keypress in DefaultKeys.select:

--- a/test/beaupy_select_multiple_test.py
+++ b/test/beaupy_select_multiple_test.py
@@ -91,7 +91,7 @@ def _():
             renderable="\\[[pink1]😋[/pink1]] test1\n\\[[pink1]😋[/pink1]] [pink1]test2[/pink1]\n\n(Mark with [bold]space[/bold], confirm with [bold]enter[/bold])"
         ),
         mock.call(
-            renderable="\\[[pink1]😋[/pink1]] test1\n\\[[pink1]😋[/pink1]] [pink1]test2[/pink1]\n\n(Mark with [bold]space[/bold], confirm with [bold]enter[/bold])"
+            renderable="\\[[pink1]😋[/pink1]] [pink1]test1[/pink1]\n\\[[pink1]😋[/pink1]] test2\n\n(Mark with [bold]space[/bold], confirm with [bold]enter[/bold])"
         ),
     ]
     assert Live.update.call_count == 5
@@ -114,14 +114,14 @@ def _():
             renderable="\\[[pink1]😋[/pink1]] [pink1]test1[/pink1]\n\\[  ] test2\n\n(Mark with [bold]space[/bold], confirm with [bold]enter[/bold])"
         ),
         mock.call(
-            renderable="\\[[pink1]😋[/pink1]] [pink1]test1[/pink1]\n\\[  ] test2\n\n(Mark with [bold]space[/bold], confirm with [bold]enter[/bold])"
+            renderable="\\[[pink1]😋[/pink1]] test1\n\\[  ] [pink1]test2[/pink1]\n\n(Mark with [bold]space[/bold], confirm with [bold]enter[/bold])"
         ),
         mock.call(
-            renderable="\\[  ] [pink1]test1[/pink1]\n\\[  ] test2\n\n(Mark with [bold]space[/bold], confirm with [bold]enter[/bold])"
+            renderable="\\[[pink1]😋[/pink1]] test1\n\\[[pink1]😋[/pink1]] [pink1]test2[/pink1]\n\n(Mark with [bold]space[/bold], confirm with [bold]enter[/bold])"
         ),
     ]
     assert Live.update.call_count == 4
-    assert res == []
+    assert res == ['test1', 'test2']
 
 
 @test(

--- a/test/beaupy_select_test.py
+++ b/test/beaupy_select_test.py
@@ -114,10 +114,10 @@ def _():
 
     assert Live.update.call_args_list == [
         mock.call(renderable="[green]x[/green] test1\n  test2\n  test3\n  test4\n\n(Confirm with [bold]enter[/bold])"),
-        mock.call(renderable="[green]x[/green] test1\n  test2\n  test3\n  test4\n\n(Confirm with [bold]enter[/bold])"),
+        mock.call(renderable="  test1\n  test2\n  test3\n[green]x[/green] test4\n\n(Confirm with [bold]enter[/bold])"),
     ]
     assert Live.update.call_count == 2
-    assert res == "test1"
+    assert res == "test4"
 
 
 @test("`select` with 4 options stepping up and selecting last with `x` as a cursor and `green` as a cursor color")


### PR DESCRIPTION
# Updated:
- Allows the user to press down when at the bottom of a list to send the cursor/index back to the top.
- Ditto ^^ but for when the user is at the top of a list and presses up. 

<br />

# Left alone:
- I didn't touch the "confirm" function as it is just 2 options and is basically a True or False check and I like it how it is.
- I didn't touch the "prompt" function as it is unrelated.

<br />
<br />

# Why?:
When you start to have pretty BIG lists, say 20 options for example...it will take some time to get all the way back to the top of the list of options. Same for when you want to get to the bottom of the list. I would have to tap the down arrow key like 19 times to get to the bottom. I can now just press up 1 time and BAM, bottom of the list. (Same for being at the bottom and getting back to the top) 
__ __

<br />
<br />


# Tested with:
> Successfully. 
- Python Version: v3.10
- OS: Manjaro Linux x86_64
- Kernel: 5.15.85-1-MANJARO 
__ __