### PR TITLE
feat: Add vi movement keys in selection menu

### DIFF
--- a/beaupy/_beaupy.py
+++ b/beaupy/_beaupy.py
@@ -226,12 +226,16 @@ def select(
                 if Config.raise_on_interrupt:
                     raise KeyboardInterrupt()
                 return None
-            elif keypress in DefaultKeys.up:
+            elif keypress in DefaultKeys.up or str(keypress) == 'k':
                 index -= 1
                 index = index % len(options)
-            elif keypress in DefaultKeys.down:
+            elif keypress in DefaultKeys.down or str(keypress) == 'j':
                 index += 1
                 index = index % len(options)
+            elif str(keypress) == 'g':
+                index = 0
+            elif str(keypress) == 'G':
+                index = len(options) - 1
             elif keypress in DefaultKeys.confirm:
                 if return_index:
                     return index

--- a/beaupy/_beaupy.py
+++ b/beaupy/_beaupy.py
@@ -226,15 +226,15 @@ def select(
                 if Config.raise_on_interrupt:
                     raise KeyboardInterrupt()
                 return None
-            elif keypress in DefaultKeys.up or str(keypress) == 'k':
+            elif keypress in DefaultKeys.up:
                 index -= 1
                 index = index % len(options)
-            elif keypress in DefaultKeys.down or str(keypress) == 'j':
+            elif keypress in DefaultKeys.down:
                 index += 1
                 index = index % len(options)
-            elif str(keypress) == 'g':
+            elif keypress in DefaultKeys.home:
                 index = 0
-            elif str(keypress) == 'G':
+            elif keypress in DefaultKeys.end:
                 index = len(options) - 1
             elif keypress in DefaultKeys.confirm:
                 if return_index:
@@ -336,6 +336,10 @@ def select_multiple(
             elif keypress in DefaultKeys.down:
                 index += 1
                 index = index % len(options)
+            elif keypress in DefaultKeys.home:
+                index = 0
+            elif keypress in DefaultKeys.end:
+                index = len(options) - 1
             elif keypress in DefaultKeys.select:
                 if index in ticked_indices:
                     ticked_indices.remove(index)

--- a/test/beaupy_select_multiple_test.py
+++ b/test/beaupy_select_multiple_test.py
@@ -151,6 +151,55 @@ def _():
     assert res == [0, 1]
 
 
+@test("`select_multiple` with moving down then pressing home and selecting first")
+def _():
+    steps = iter([Keys.DOWN_ARROW, Keys.HOME, ' ', Keys.ENTER])
+    b.get_key = lambda: next(steps)
+    Live.update = mock.MagicMock()
+    res = select_multiple(options=["test1", "test2"], tick_character="😋")
+
+    assert Live.update.call_args_list == [
+        mock.call(
+            renderable="\\[  ] [pink1]test1[/pink1]\n\\[  ] test2\n\n(Mark with [bold]space[/bold], confirm with [bold]enter[/bold])"
+        ),
+        mock.call(
+            renderable="\\[  ] test1\n\\[  ] [pink1]test2[/pink1]\n\n(Mark with [bold]space[/bold], confirm with [bold]enter[/bold])"
+        ),
+        mock.call(
+            renderable="\\[  ] [pink1]test1[/pink1]\n\\[  ] test2\n\n(Mark with [bold]space[/bold], confirm with [bold]enter[/bold])"
+        ),
+       mock.call(
+            renderable="\\[[pink1]😋[/pink1]] [pink1]test1[/pink1]\n\\[  ] test2\n\n(Mark with [bold]space[/bold], confirm with [bold]enter[/bold])"
+        ),
+    ]
+
+    assert Live.update.call_count == 4
+    assert res == ["test1"]
+
+
+@test("`select_multiple` with pressing end and selecting last")
+def _():
+    steps = iter([Keys.END, ' ', Keys.ENTER])
+    b.get_key = lambda: next(steps)
+    Live.update = mock.MagicMock()
+    res = select_multiple(options=["test1", "test2"], tick_character="😋")
+
+    assert Live.update.call_args_list == [
+        mock.call(
+            renderable="\\[  ] [pink1]test1[/pink1]\n\\[  ] test2\n\n(Mark with [bold]space[/bold], confirm with [bold]enter[/bold])"
+        ),
+        mock.call(
+            renderable="\\[  ] test1\n\\[  ] [pink1]test2[/pink1]\n\n(Mark with [bold]space[/bold], confirm with [bold]enter[/bold])"
+        ),
+        mock.call(
+            renderable="\\[  ] test1\n\\[[pink1]😋[/pink1]] [pink1]test2[/pink1]\n\n(Mark with [bold]space[/bold], confirm with [bold]enter[/bold])"
+        ),
+    ]
+
+    assert Live.update.call_count == 3
+    assert res == ["test2"]
+
+
 @test(
     "`select_multiple` with 2 options `x` as tick character and yellow1 as color starting from second selecting and going up",
 )

--- a/test/beaupy_select_test.py
+++ b/test/beaupy_select_test.py
@@ -56,6 +56,40 @@ def _():
     assert Live.update.call_count == 2
 
 
+@test("`select` with pressing end")
+def _():
+    steps = iter([Keys.END, Keys.ENTER])
+    b.get_key = lambda: next(steps)
+    Live.update = mock.MagicMock()
+    res = select(options=["test1", "test2", "test3", "test4"])
+
+    assert Live.update.call_args_list == [
+        mock.call(renderable="[pink1]>[/pink1] test1\n  test2\n  test3\n  test4\n\n(Confirm with [bold]enter[/bold])"),
+        mock.call(renderable="  test1\n  test2\n  test3\n[pink1]>[/pink1] test4\n\n(Confirm with [bold]enter[/bold])"),
+    ]
+
+    assert Live.update.call_count == 2
+    assert res == "test4"
+
+
+@test("`select` with pressing down twice and selecting first with home")
+def _():
+    steps = iter([Keys.DOWN_ARROW, Keys.DOWN_ARROW, Keys.HOME, Keys.ENTER])
+    b.get_key = lambda: next(steps)
+    Live.update = mock.MagicMock()
+    res = select(options=["test1", "test2", "test3", "test4"])
+
+    assert Live.update.call_args_list == [
+        mock.call(renderable="[pink1]>[/pink1] test1\n  test2\n  test3\n  test4\n\n(Confirm with [bold]enter[/bold])"),
+        mock.call(renderable="  test1\n[pink1]>[/pink1] test2\n  test3\n  test4\n\n(Confirm with [bold]enter[/bold])"),
+        mock.call(renderable="  test1\n  test2\n[pink1]>[/pink1] test3\n  test4\n\n(Confirm with [bold]enter[/bold])"),
+        mock.call(renderable="[pink1]>[/pink1] test1\n  test2\n  test3\n  test4\n\n(Confirm with [bold]enter[/bold])"),
+    ]
+
+    assert Live.update.call_count == 4
+    assert res == "test1"
+
+
 @test("`select` with 4 options stepping down through all with random character inbetween and selecting last")
 def _():
     steps = iter(


### PR DESCRIPTION
I often find myself absent mindedly switching between using VI keybinds and the arrow keys in terminal apps. This PR adds using 'j' and 'k' to move up and down and 'g' and 'G' to move to the beginning and end of the selection.