### PR TITLE
Escape key can raise Abort

### DIFF
--- a/beaupy/__init__.py
+++ b/beaupy/__init__.py
@@ -8,4 +8,4 @@ from beaupy._beaupy import (  # noqa
     select,
     select_multiple,
 )
-from beaupy._internals import ConversionError, ValidationError  # noqa
+from beaupy._internals import Abort, ConversionError, ValidationError  # noqa

--- a/beaupy/_beaupy.py
+++ b/beaupy/_beaupy.py
@@ -14,6 +14,7 @@ from yakh import get_key
 from yakh.key import Keys
 
 from beaupy._internals import (
+    Abort,
     ConversionError,
     TargetType,
     ValidationError,
@@ -69,6 +70,7 @@ class Config:
     """
 
     raise_on_interrupt: bool = False
+    raise_on_escape: bool = False
 
 
 def prompt(
@@ -141,8 +143,6 @@ def prompt(
             elif keypress in DefaultKeys.right:
                 if cursor_index < len(value):
                     cursor_index += 1
-            elif keypress in DefaultKeys.escape:
-                return None
             elif keypress in DefaultKeys.up + DefaultKeys.down:
                 pass
             elif keypress in DefaultKeys.home:
@@ -152,6 +152,10 @@ def prompt(
             elif keypress in DefaultKeys.delete:
                 if cursor_index < len(value):
                     del value[cursor_index]
+            elif keypress in DefaultKeys.escape:
+                if Config.raise_on_escape:
+                    raise Abort(keypress)
+                return None
             else:
                 value.insert(cursor_index, str(keypress))
                 cursor_index += 1
@@ -236,6 +240,8 @@ def select(
                     return index
                 return options[index]
             elif keypress in DefaultKeys.escape:
+                if Config.raise_on_escape:
+                    raise Abort(keypress)
                 return None
 
 
@@ -351,6 +357,8 @@ def select_multiple(
                 else:
                     break
             elif keypress in DefaultKeys.escape:
+                if Config.raise_on_escape:
+                    raise Abort(keypress)
                 return []
         if return_indices:
             return ticked_indices
@@ -419,14 +427,16 @@ def confirm(
             elif keypress in DefaultKeys.backspace:
                 if current_message:
                     current_message = current_message[:-1]
-            elif keypress in DefaultKeys.escape:
-                return None
             elif keypress in DefaultKeys.confirm:
                 if is_selected:
                     break
             elif keypress in DefaultKeys.tab:
                 if is_selected:
                     current_message = yes_text if is_yes else no_text
+            elif keypress in DefaultKeys.escape:
+                if Config.raise_on_escape:
+                    raise Abort(keypress)
+                return None
             else:
                 current_message += str(keypress)
                 match_yes = yes_text

--- a/beaupy/_internals.py
+++ b/beaupy/_internals.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Iterator, List, Type, Union
 import emoji
 from rich.console import Console, ConsoleRenderable
 from rich.live import Live
+from yakh.key import Key
 
 TargetType = Any
 
@@ -15,6 +16,14 @@ class ValidationError(Exception):
 
 class ConversionError(Exception):
     pass
+
+
+class Abort(Exception):
+    key: Key
+
+    def __init__(self, key: Key) -> None:
+        super().__init__(f'Aborted by user with key {key.key if key.is_printable else key.key_codes}')
+        self.key = key
 
 
 def _replace_emojis(text: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'beaupy'
-version = '3.3.1'
+version = '3.4.0'
 description = 'A library of elements for interactive TUIs in Python'
 authors = ['Peter Vyboch <pvyboch1@gmail.com>']
 license = 'MIT'

--- a/test/beaupy_internals_test.py
+++ b/test/beaupy_internals_test.py
@@ -1,6 +1,7 @@
 from ward import test
 
-from beaupy._internals import _render_prompt
+from beaupy._internals import _render_prompt, Abort
+from yakh.key import Key
 
 
 @test("Test that prompt is rendered properly")
@@ -15,3 +16,19 @@ def _():
     assert (
         result == "Test prompt\n> a[black on white]b[/black on white] \n\n(Confirm with [bold]enter[/bold])\n[red]Error:[/red] Test Error"
     )
+
+@test("Test that abort prints printable key correctly")
+def _():
+    key = Key("test", (1,2,3), is_printable=True)
+    try:
+        raise Abort(key)
+    except Abort as e:
+        assert str(e) == "Aborted by user with key test"
+
+@test("Test that abort prints non-printable key correctly")
+def _():
+    key = Key("test", (1,2,3), is_printable=False)
+    try:
+        raise Abort(key)
+    except Abort as e:
+        assert str(e) == "Aborted by user with key (1, 2, 3)"


### PR DESCRIPTION
Changes:
- Included config option `Config.raise_on_escape`
- Included `Abort` exception containing the key which caused it to be raised
- Extended `select` to raise Abort on escape if `Config.raise_on_escape` is `True`
- Extended `select_multiple` to raise Abort on escape if `Config.raise_on_escape` is `True`
- Extended `prompt` to raise Abort on escape if `Config.raise_on_escape` is `True`
- Extended `confirm` to raise Abort on escape if `Config.raise_on_escape` is `True`

Addresses #50 