### PR TITLE
Created a Separator System

### DIFF
--- a/beaupy/__init__.py
+++ b/beaupy/__init__.py
@@ -7,5 +7,6 @@ from beaupy._beaupy import (  # noqa
     prompt,
     select,
     select_multiple,
+    pause
 )
 from beaupy._internals import Abort, ConversionError, ValidationError  # noqa

--- a/beaupy/__init__.py
+++ b/beaupy/__init__.py
@@ -6,6 +6,6 @@ from beaupy._beaupy import (  # noqa
     console,
     prompt,
     select,
-    select_multiple
+    select_multiple,
 )
 from beaupy._internals import Abort, ConversionError, ValidationError  # noqa

--- a/beaupy/__init__.py
+++ b/beaupy/__init__.py
@@ -6,7 +6,6 @@ from beaupy._beaupy import (  # noqa
     console,
     prompt,
     select,
-    select_multiple,
-    pause
+    select_multiple
 )
 from beaupy._internals import Abort, ConversionError, ValidationError  # noqa

--- a/beaupy/_beaupy.py
+++ b/beaupy/_beaupy.py
@@ -509,20 +509,3 @@ def confirm(
                 else:
                     is_selected = False
         return is_selected and is_yes
-
-
-def pause(
-        prompt: Optional[str] = None
-) -> bool:
-    """Similar to Batch pause function, holds the script until any key is pressed
-
-    Args:
-        prompt (str): Text prompt to show on screen
-
-    Returns:
-        bool: true, after key pressed
-    """
-    if prompt is not None:
-        console.print(prompt, end="", highlight=False)
-    if (get_key()):
-        return True

--- a/beaupy/_beaupy.py
+++ b/beaupy/_beaupy.py
@@ -509,3 +509,20 @@ def confirm(
                 else:
                     is_selected = False
         return is_selected and is_yes
+
+
+def pause(
+        prompt: Optional[str] = None
+) -> bool:
+    """Similar to Batch pause function, holds the script until any key is pressed
+
+    Args:
+        prompt (str): Text prompt to show on screen
+
+    Returns:
+        bool: true, after key pressed
+    """
+    if prompt is not None:
+        console.print(prompt, end="", highlight=False)
+    if (get_key()):
+        return True

--- a/beaupy/_beaupy.py
+++ b/beaupy/_beaupy.py
@@ -93,17 +93,24 @@ def _navigate_select(
     page_size: int,
     show_from: int,
     show_to: int,
+    options: list
 ) -> Tuple[int, int]:
     if keypress in DefaultKeys.up:
         if index <= show_from and pagination:
             page = _paginate_back(page, total_pages)
         index -= 1
         index = index % total_options
+        if (options[index].startswith(":SEPARATOR:")):
+            index -= 1
+            index = index % total_options
     elif keypress in DefaultKeys.down:
         if index > show_to - 2 and pagination:
             page = _paginate_forward(page, total_pages)
         index += 1
         index = index % total_options
+        if (options[index].startswith(":SEPARATOR:")):
+            index += 1
+            index = index % total_options
     elif keypress in DefaultKeys.right and pagination:
         page = _paginate_forward(page, total_pages)
         index = (page - 1) * page_size
@@ -283,7 +290,7 @@ def select(
                     raise KeyboardInterrupt()
                 return None
             elif any([keypress in navigation_keys for navigation_keys in _navigation_keys]):
-                index, page = _navigate_select(index, page, keypress, len(options), pagination, total_pages, page_size, show_from, show_to)
+                index, page = _navigate_select(index, page, keypress, len(options), pagination, total_pages, page_size, show_from, show_to, options)
             elif keypress in DefaultKeys.confirm:
                 if return_index:
                     return index
@@ -387,7 +394,7 @@ def select_multiple(
                     raise KeyboardInterrupt()
                 return []
             elif any([keypress in navigation_keys for navigation_keys in _navigation_keys]):
-                index, page = _navigate_select(index, page, keypress, len(options), pagination, total_pages, page_size, show_from, show_to)
+                index, page = _navigate_select(index, page, keypress, len(options), pagination, total_pages, page_size, show_from, show_to, options)
             elif keypress in DefaultKeys.select:
                 if index in ticked_indices:
                     ticked_indices.remove(index)


### PR DESCRIPTION
This allows the `select` and `select_multiple` to have separators in the middle if they are prefixed with `:SEPARATOR:`.
It could also be used to put a description for another option.

```python
names = [
    "Frodo Baggins",
    "Samwise Gamgee",
    "Legolas",
    "Aragorn",
    ":SEPARATOR:" + ("=" * 32),
    "[red]Sauron[/red]",
]
# Choose one item from a list
name = select(names, cursor="🢧", cursor_style="cyan")
```

This example with add a separator above the last option.