### PR TITLE
Feature: Add Title Property to select and select_multiple Inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,8 @@ if confirm("Will you take the ring to Mordor?"):
         "Aragorn",
         "[red]Sauron[/red]",
     ]
-    console.print("Who are you?")
     # Choose one item from a list
-    name = select(names, cursor="🢧", cursor_style="cyan")
+    name = select(names, title="Who are you?", cursor="🢧", cursor_style="cyan")
     console.print(f"Alámenë, {name}")
     
     
@@ -63,9 +62,8 @@ if confirm("Will you take the ring to Mordor?"):
         "Po-tae-toes",
         "Lightsaber (Wrong franchise! Nevermind, roll with it!)",
     ]
-    console.print("What do you bring with you?")
     # Choose multiple options from a list
-    items = select_multiple(item_options, tick_character='🎒', ticked_indices=[0], maximal_count=3)
+    items = select_multiple(item_options, title="What do you bring with you?", tick_character='🎒', ticked_indices=[0], maximal_count=3)
     
     potato_count = 0
     if "Po-tae-toes" in items:

--- a/beaupy/_beaupy.py
+++ b/beaupy/_beaupy.py
@@ -245,7 +245,7 @@ def select(
 
     Args:
         options (List[Union[Tuple[int, ...], str]]): A list of options to select from
-        title (str): The title that will be displayed above the options list
+        title (str, optional): The title that will be displayed above the options list
         preprocessor (Callable[[Any], Any]): A callable that can be used to preprocess the list of options prior to printing.
                                              For example, if you passed a `Person` object with `name` attribute, preprocessor
                                              could be `lambda person: person.name` to just show the content of `name` attribute
@@ -338,7 +338,7 @@ def select_multiple(
 
     Args:
         options (List[Union[Tuple[int, ...], str]]): A list of options to select from
-        title (str): The title that will be displayed above the options list
+        title (str, optional): The title that will be displayed above the options list
         preprocessor (Callable[[Any], Any]): A callable that can be used to preprocess the list of options prior to printing.
                                              For example, if you passed a `Person` object with `name` attribute, preprocessor
                                              could be `lambda person: person.name` to just show the content of `name` attribute

--- a/beaupy/_beaupy.py
+++ b/beaupy/_beaupy.py
@@ -284,7 +284,7 @@ def select(
             show_from = (page - 1) * page_size
             show_to = min(show_from + page_size, len(options))
             rendered = (  # noqa: ECE001
-                f'{title}\n'
+                f'{title}\n' if title is not None else ''
                 + '\n'.join(
                     [
                         _format_option_select(
@@ -388,7 +388,7 @@ def select_multiple(
             show_from = (page - 1) * page_size
             show_to = min(show_from + page_size, len(options))
             rendered = (  # noqa: ECE001
-                f'{title}\n'
+                f'{title}\n' if title is not None else ''
                 + '\n'.join(
                     [
                         _render_option_select_multiple(

--- a/beaupy/_beaupy.py
+++ b/beaupy/_beaupy.py
@@ -231,7 +231,7 @@ def prompt(
 
 def select(
     options: List[Union[Tuple[int, ...], str]],
-    title: Union[str, None] = None,
+    title: Optional[str] = None,
     preprocessor: Callable[[Any], Any] = lambda val: val,
     cursor: str = '>',
     cursor_style: str = 'pink1',
@@ -320,7 +320,7 @@ def select(
 
 def select_multiple(
     options: List[Union[Tuple[int, ...], str]],
-    title: Union[str, None] = None,
+    title: Optional[str] = None,
     preprocessor: Callable[[Any], Any] = lambda val: val,
     tick_character: str = '✓',
     tick_style: str = 'pink1',

--- a/beaupy/_beaupy.py
+++ b/beaupy/_beaupy.py
@@ -231,7 +231,7 @@ def prompt(
 
 def select(
     options: List[Union[Tuple[int, ...], str]],
-    title: str = None,
+    title: Union[str, None] = None,
     preprocessor: Callable[[Any], Any] = lambda val: val,
     cursor: str = '>',
     cursor_style: str = 'pink1',
@@ -284,8 +284,8 @@ def select(
             show_from = (page - 1) * page_size
             show_to = min(show_from + page_size, len(options))
             rendered = (  # noqa: ECE001
-                f'{title}\n' if title is not None else ''
-                + '\n'.join(
+                (f'{title}\n' if title is not None else '')
+                + '\n'.join(  # noqa: W503
                     [
                         _format_option_select(
                             i=i,
@@ -309,7 +309,6 @@ def select(
             elif any([keypress in navigation_keys for navigation_keys in _navigation_keys]):
                 index, page = _navigate_select(index, page, keypress, len(options), pagination, total_pages, page_size, show_from, show_to)
             elif keypress in DefaultKeys.confirm:
-                _update_rendered(live, '')
                 if return_index:
                     return index
                 return options[index]
@@ -321,7 +320,7 @@ def select(
 
 def select_multiple(
     options: List[Union[Tuple[int, ...], str]],
-    title: str = None,
+    title: Union[str, None] = None,
     preprocessor: Callable[[Any], Any] = lambda val: val,
     tick_character: str = '✓',
     tick_style: str = 'pink1',
@@ -388,8 +387,8 @@ def select_multiple(
             show_from = (page - 1) * page_size
             show_to = min(show_from + page_size, len(options))
             rendered = (  # noqa: ECE001
-                f'{title}\n' if title is not None else ''
-                + '\n'.join(
+                (f'{title}\n' if title is not None else '')
+                + '\n'.join(  # noqa: W503
                     [
                         _render_option_select_multiple(
                             option=preprocessor(option),

--- a/beaupy/_beaupy.py
+++ b/beaupy/_beaupy.py
@@ -30,7 +30,7 @@ from beaupy._internals import (
     _validate_prompt_value,
 )
 
-console = Console(highlight=False)
+console = Console()
 
 
 class DefaultKeys:


### PR DESCRIPTION
This PR introduces a new `title` property for both `select` and `select_multiple` input types.

### Changes:
- Added `title` property to `select` and `select_multiple` inputs.
- Updated examples in README.md.

### Motivation:
The `prompt` input in `beaupy` offers an interactive way for users to input data, where the question disappears upon confirmation. This PR brings the `select` and `select_multiple` inputs in line with this behavior, making the user experience more consistent and intuitive.
<br>
Please review the changes and provide feedback. Looking forward to integrating this enhancement to improve the user interaction in `beaupy`.
