### PR TITLE
Remove warning about invalid escape sequence

### DIFF
--- a/beaupy/_internals.py
+++ b/beaupy/_internals.py
@@ -57,7 +57,7 @@ def _wrap_style(string_w_styles: str, global_style_str: str) -> str:
 def _render_option_select_multiple(
     option: str, ticked: bool, tick_character: str, tick_style: str, selected: bool, cursor_style: str
 ) -> str:
-    prefix = r'\[{}]'.format(' ' * len(_replace_emojis(tick_character))) 
+    prefix = r'\[{}]'.format(' ' * len(_replace_emojis(tick_character)))
     if ticked:
         prefix = rf'\[[{tick_style}]{tick_character}[/{tick_style}]]'
     if selected:


### PR DESCRIPTION
Python 3.12 now issues this as a warning at runtime, not just a flake8/linter error.

I'm not quite sure why my script complains about this when `python -c 'import beaupy._internals'` doesn't, but it seems like an easy fix:

```
shell ❯ ./py312-test/bin/teleport-assume
/Users/ash/code/astro/teleport-assume/py312-test/lib/python3.12/site-packages/beaupy/_internals.py:60: SyntaxWarning: invalid escape sequence '\['
  prefix = '\[{}]'.format(' ' * len(_replace_emojis(tick_character)))  # noqa: W605
/Users/ash/code/astro/teleport-assume/py312-test/lib/python3.12/site-packages/beaupy/_internals.py:62: SyntaxWarning: invalid escape sequence '\['
  prefix = f'\[[{tick_style}]{tick_character}[/{tick_style}]]'  # noqa: W605
```

This was the output I got on startup of my script. (Maybe some other module I imported changed the default warnings filter 🤷🏻 )