### PR TITLE
Update _internals.py

### DIFF
--- a/beaupy/_internals.py
+++ b/beaupy/_internals.py
@@ -50,7 +50,8 @@ def _wrap_style(string_w_styles: str, global_style_str: str) -> str:
     for style_string in style_strings:
         try:
             style = Style.combine([Style.parse(style_string), global_style])
-            string_w_styles = string_w_styles.replace(f'[{style_string}]', f'[{style}]').replace(f'[/{style_string}]', f'[/{style}]')
+            string_w_styles = string_w_styles.replace(f'[{style_string}]', f'[{style}]')
+            string_w_styles = string_w_styles.replace(f'[/{style_string}]', f'[/{style}]')
         except Exception:
             # In the case where there are non style defining square brakets in the string, ignores invalid colors in square brakets, since these aren't styles
             continue

--- a/beaupy/_internals.py
+++ b/beaupy/_internals.py
@@ -50,8 +50,8 @@ def _wrap_style(string_w_styles: str, global_style_str: str) -> str:
     for style_string in style_strings:
         try:
             style = Style.combine([Style.parse(style_string), global_style])
-            string_w_styles = string_w_styles.replace(f'[{style_string}]', f'[{style}]')
-        except:
+            string_w_styles = string_w_styles.replace(f'[{style_string}]', f'[{style}]').replace(f'[/{style_string}]', f'[/{style}]')
+        except Exception:
             # In the case where there are non style defining square brakets in the string, ignores invalid colors in square brakets, since these aren't styles
             continue
 

--- a/beaupy/_internals.py
+++ b/beaupy/_internals.py
@@ -43,13 +43,17 @@ def _render_option_select(i: int, cursor_index: int, option: str, cursor_style: 
 
 
 def _wrap_style(string_w_styles: str, global_style_str: str) -> str:
-    RE_STYLE_PATTERN = r'\[(.*?)\]'
+    RE_STYLE_PATTERN = r'\[(/?[^]]+)\]'
 
     global_style = Style.parse(global_style_str)
-    style_strings = list(set([i.replace('/', '') for i in re.findall(RE_STYLE_PATTERN, string_w_styles)]))
+    style_strings = list(set(re.findall(RE_STYLE_PATTERN, string_w_styles)))
     for style_string in style_strings:
-        style = Style.combine([Style.parse(style_string), global_style])
-        string_w_styles = string_w_styles.replace(f'{style_string}', f'{style}')
+        try:
+            style = Style.combine([Style.parse(style_string), global_style])
+            string_w_styles = string_w_styles.replace(f'[{style_string}]', f'[{style}]')
+        except:
+            # In the case where there are non style defining square brakets in the string, ignores invalid colors in square brakets, since these aren't styles
+            continue
 
     return f'[{global_style_str}]{string_w_styles}[/{global_style_str}]'
 

--- a/beaupy/_internals.py
+++ b/beaupy/_internals.py
@@ -53,7 +53,8 @@ def _wrap_style(string_w_styles: str, global_style_str: str) -> str:
             string_w_styles = string_w_styles.replace(f'[{style_string}]', f'[{style}]')
             string_w_styles = string_w_styles.replace(f'[/{style_string}]', f'[/{style}]')
         except Exception:
-            # In the case where there are non style defining square brakets in the string, ignores invalid colors in square brakets, since these aren't styles
+            # In the case where there are non style defining square brakets in the string,
+            # ignores invalid colors in square brakets, since these aren't styles
             continue
 
     return f'[{global_style_str}]{string_w_styles}[/{global_style_str}]'


### PR DESCRIPTION
I ran into a bug when the option string passed into `select_multiple` contain square bracket characters.

My cursor line shows something like this:
[ ] greenBgreenDgreen green-green greenEgreenxgreenagreenmgreenpgreenlgreenegreen greenCgreenlgreenigreenegreenngreentgreen greengreen

while the others lines all show the selected cursor style
[ ] PX - Polite Xray []  <- this is all green when not selected

If there was any characters in-between the square brackets, upon moving the cursor to that option, I would get an error saying the text in-between the square brackets wasn't a valid color, obviously.