### PR TITLE
Copy button added to code block in documentation

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -19,7 +19,10 @@ theme:
       toggle:
         icon: material/weather-sunny
         name: Switch to light mode
-
+        
+  features:
+    - content.code.copy
+    
 site_name: BeauPy
 
 markdown_extensions:

--- a/poetry.lock
+++ b/poetry.lock
@@ -531,17 +531,20 @@ test = ["black", "pytest"]
 
 [[package]]
 name = "emoji"
-version = "2.10.1"
+version = "2.12.1"
 description = "Emoji for Python"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.7"
 files = [
-    {file = "emoji-2.10.1-py2.py3-none-any.whl", hash = "sha256:11fb369ea79d20c14efa4362c732d67126df294a7959a2c98bfd7447c12a218e"},
-    {file = "emoji-2.10.1.tar.gz", hash = "sha256:16287283518fb7141bde00198f9ffff4e1c1cb570efb68b2f1ec50975c3a581d"},
+    {file = "emoji-2.12.1-py3-none-any.whl", hash = "sha256:a00d62173bdadc2510967a381810101624a2f0986145b8da0cffa42e29430235"},
+    {file = "emoji-2.12.1.tar.gz", hash = "sha256:4aa0488817691aa58d83764b6c209f8a27c0b3ab3f89d1b8dceca1a62e4973eb"},
 ]
 
+[package.dependencies]
+typing-extensions = ">=4.7.0"
+
 [package.extras]
-dev = ["coverage", "coveralls", "pytest"]
+dev = ["coverage", "pytest (>=7.4.4)"]
 
 [[package]]
 name = "eradicate"
@@ -751,13 +754,13 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.42"
+version = "3.1.43"
 description = "GitPython is a Python library used to interact with Git repositories"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "GitPython-3.1.42-py3-none-any.whl", hash = "sha256:1bf9cd7c9e7255f77778ea54359e54ac22a72a5b51288c457c881057b7bb9ecd"},
-    {file = "GitPython-3.1.42.tar.gz", hash = "sha256:2d99869e0fef71a73cbd242528105af1d6c1b108c60dfabd994bf292f76c3ceb"},
+    {file = "GitPython-3.1.43-py3-none-any.whl", hash = "sha256:eec7ec56b92aad751f9912a73404bc02ba212a23adb2c7098ee668417051a1ff"},
+    {file = "GitPython-3.1.43.tar.gz", hash = "sha256:35f314a9f878467f5453cc1fee295c3e18e52f1b99f10f6cf5b1682e968a9e7c"},
 ]
 
 [package.dependencies]
@@ -765,7 +768,8 @@ gitdb = ">=4.0.1,<5"
 typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.8\""}
 
 [package.extras]
-test = ["black", "coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock", "mypy", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar"]
+doc = ["sphinx (==4.3.2)", "sphinx-autodoc-typehints", "sphinx-rtd-theme", "sphinxcontrib-applehelp (>=1.0.2,<=1.0.4)", "sphinxcontrib-devhelp (==1.0.2)", "sphinxcontrib-htmlhelp (>=2.0.0,<=2.0.1)", "sphinxcontrib-qthelp (==1.0.3)", "sphinxcontrib-serializinghtml (==1.1.5)"]
+test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock", "mypy", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions"]
 
 [[package]]
 name = "idna"
@@ -1563,13 +1567,13 @@ files = [
 
 [[package]]
 name = "tomlkit"
-version = "0.12.4"
+version = "0.12.5"
 description = "Style preserving TOML library"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "tomlkit-0.12.4-py3-none-any.whl", hash = "sha256:5cd82d48a3dd89dee1f9d64420aa20ae65cfbd00668d6f094d7578a78efbb77b"},
-    {file = "tomlkit-0.12.4.tar.gz", hash = "sha256:7ca1cfc12232806517a8515047ba66a19369e71edf2439d0f5824f91032b6cc3"},
+    {file = "tomlkit-0.12.5-py3-none-any.whl", hash = "sha256:af914f5a9c59ed9d0762c7b64d3b5d5df007448eb9cd2edc8a46b1eafead172f"},
+    {file = "tomlkit-0.12.5.tar.gz", hash = "sha256:eef34fba39834d4d6b73c9ba7f3e4d1c417a4e56f89a7e96e090dd0d24b8fb3c"},
 ]
 
 [[package]]
@@ -1686,13 +1690,13 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "ward"
-version = "0.67.2b0"
+version = "0.68.0b0"
 description = "A modern Python testing framework"
 optional = false
 python-versions = ">=3.7.8,<4.0.0"
 files = [
-    {file = "ward-0.67.2b0-py3-none-any.whl", hash = "sha256:fe351f5ae2fbbf8132af6260bdea8245dcef026943cb2084faaa48e6a1017c4e"},
-    {file = "ward-0.67.2b0.tar.gz", hash = "sha256:11bf0128e4696bfd1ca9a2b457c817378c4479a33fa45d0e3aabf7b301744f47"},
+    {file = "ward-0.68.0b0-py3-none-any.whl", hash = "sha256:0847e6b95db9d2b83c7d1b9cea9bcb7ac3b8e8f6d341b8dc8920d6afb05458b1"},
+    {file = "ward-0.68.0b0.tar.gz", hash = "sha256:d8aafa4ddb81f4d5787d95bdb2f7ba69a2e89f183feec78d8afcc64b2cd19ee9"},
 ]
 
 [package.dependencies]
@@ -1884,4 +1888,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7.8,<4.0.0"
-content-hash = "d4313ce205054dd445fb58cf4e22474eb207f9778cf0c9b48b5d17b318804163"
+content-hash = "dec265242505b127670625b5b1ddc936d53a73ebad11a7ef76c051f3d15fae2e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ add = { shell = 'poetry add' }
 install = { shell = 'poetry install' }
 build = { shell = 'poetry build' }
 clean = { shell = 'rm -R ./dist .pytest_cache .mypy_cache &> /dev/null' }
-
 isort = { shell = 'poetry run isort ./beaupy' }
 black = { shell = 'poetry run black ./beaupy --skip-string-normalization' }
 mypy = { shell = 'poetry run mypy ./beaupy/' }
@@ -33,7 +32,6 @@ flake8 = { shell = 'poetry run pflake8 ./beaupy/' }
 perflint = { shell = "poetry run perflint ./beaupy/" }
 lint = { shell = 'echo "Running isort..." ; poetry run poe isort; echo "Running black..." ; poetry run poe black ; echo "Running unify..." ; poetry run unify ./beaupy -r -i ; echo "Running flake8..." ; poetry run poe flake8 ; echo "Running mypy..." ; poetry run poe mypy ; echo Done!' }
 "lint:watch" = { shell = "poetry run poe lint ; poetry run watchmedo shell-command --patterns='*.py;*.feature;*.toml' --recursive --drop --command='poetry run poe lint'" }
-
 "test" = { shell = "poetry run ward" }
 "test:watch" = { shell = "poetry run poe test; poetry run watchmedo shell-command --patterns='*.py;*.feature;*.toml' --recursive --drop --command='poetry run poe test'" }
 
@@ -44,21 +42,16 @@ emoji = "^2.0.0"
 python-yakh = "0.3.2"
 questo = "^0.2.3"
 
-
 [tool.mypy]
-
 files = ["src"]
 warn_return_any = true
 warn_unused_configs = true
-
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
 disallow_untyped_decorators = true
-
 warn_redundant_casts = true
 warn_unreachable = true
 warn_unused_ignores = true
-
 show_column_numbers = true
 ignore_missing_imports = true
 
@@ -71,10 +64,9 @@ profile = "black"
 [tool.flake8]
 max-line-length = 140
 max-complexity = 18
-select = ["B","E","F","W","T4","B9"]
+select = ["B", "E", "F", "W", "T4", "B9"]
 
 [[tool.pydoc-markdown.loaders]]
-
 type = 'python'
 search_path = ['./beaupy']
 
@@ -92,13 +84,13 @@ report_type = ["term", "xml"]
 source = ["."]
 branch = true
 relative_files = true
-report = {skip_empty = true}
+report = { skip_empty = true }
 
 [tool.poetry.group.test.dependencies]
 expycted = '*'
 mock = '*'
 poethepoet = '*'
-ward = "^0.67.1b0"
+ward = "^0.68.0b0"
 ward-coverage = "^0.3.0"
 
 [tool.poetry.group.dev.dependencies]
@@ -107,18 +99,15 @@ mypy = '*'
 pyproject-flake8 = "*"
 flake8 = "<5"
 black = "^22.6.0"
-
 ## Bugs
 flake8-simplify = '*'
 flake8-pie = '*'
 flake8-bandit = '*'
-
 ## Complexity
 flake8-cognitive-complexity = '*'
 flake8-expression-complexity = '*'
 radon = '*'
 xenon = '*'
-
 ## Lints
 flake8-quotes = '*'
 flake8-print = '*'
@@ -127,24 +116,18 @@ flake8-comments = '*'
 toml-sort = '*'
 isort = '*'
 unify = "*"
-
 ## Performance
 perflint = '*'
-
 # Expect Pattern Testing
 expycted = '*'
-
 # Unit Testing
-ward = "^0.67.1b0"
+ward = "^0.68.0b0"
 mock = '*'
 watchdog = '*'
-
 # Coverage
 ward-coverage = "^0.3.0"
-
 # Task Runner
 poethepoet = '*'
-
 # Docs
 pydoc-markdown = "^4.6.3"
 types-emoji = "^2.0.1"


### PR DESCRIPTION
In the existing documentation, we don't have any option to copy the example code. We have to manually select and copy it. 

Material for MkDocs provides an easy way to integrate this feature. So, I have added that to our `mkdocs.yml`. This allows the users to copy the sample code easily and test it in their local system. 

Also, in future, when we add more examples, the users will be able to take advantage of the simple copy button.

**NOTE:** 
As I am facing an issue with testing the code (#97), this pull request is not tested as instructed in the [development section](https://github.com/petereon/beaupy?tab=readme-ov-file#development). However, as it is a very minor change to the yml file of the documentation (which doesn't affect the code), I believe we can skip the testing for this one.  