### PR TITLE
fix: use stderr=True for rich.Console

### DIFF
--- a/beaupy/_beaupy.py
+++ b/beaupy/_beaupy.py
@@ -33,7 +33,7 @@ from beaupy._internals import (
     _validate_prompt_value,
 )
 
-console = Console()
+console = Console(stderr=True)
 
 
 class DefaultKeys:
@@ -215,6 +215,7 @@ def prompt(
         ),
         renderer=renderer,
         transient=Config.transient,
+        console=console,
     )
 
     with element.displayed():
@@ -313,6 +314,7 @@ def select(
         ),
         renderer=renderer,
         transient=Config.transient,
+        console=console,
     )
 
     with element.displayed():
@@ -409,6 +411,7 @@ def select_multiple(
         ),
         renderer=renderer,
         transient=Config.transient,
+        console=console,
     )
 
     with element.displayed():


### PR DESCRIPTION
Currently, the output of rich console is set to stdout. This causes some issues when stdout is redirected.

To reproduce this issue, run the following code with `python test.py | grep 1`, since all escape codes are sent to the redirection target (grep) instead of the user's terminal, nothing will be rendered
```python
from beaupy import select
choices = ["1", "2", "3"]
print(select(choices))
```

This pr add `stderr=True` for rich.Console, and add the missing `console=console` for `qselect` and `qprompt`.